### PR TITLE
Report total export time

### DIFF
--- a/src/tocode/cli.py
+++ b/src/tocode/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
 
 from .analysis import create_analyzer
@@ -102,6 +103,7 @@ def main(argv: list[str] | None = None) -> int:
     args.out_dir = (
         args.out_dir.expanduser().resolve() if args.out_dir is not None else None
     )
+    started = time.monotonic()
     try:
         if not binary.is_file():
             parser.error(f"input must be a regular file: {binary}")
@@ -115,7 +117,15 @@ def main(argv: list[str] | None = None) -> int:
             f"Summary: functions={summary.function_count} "
             f"clusters={summary.cluster_count} failures={len(summary.failed_functions)}"
         )
+        print(f"Exported in {_format_duration(time.monotonic() - started)}")
     return 0
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds >= 60:
+        minutes, secs = divmod(int(round(seconds)), 60)
+        return f"{minutes}m {secs}s"
+    return f"{seconds:.1f}s"
 
 
 def _run_one(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,12 @@
 import pytest
 
-from tocode.cli import build_parser, parse_jobs
+from tocode.cli import _format_duration, build_parser, parse_jobs
+
+
+def test_format_duration_uses_seconds_then_minutes() -> None:
+    assert _format_duration(4.27) == "4.3s"
+    assert _format_duration(75) == "1m 15s"
+    assert _format_duration(3600) == "60m 0s"
 
 
 def test_parse_jobs_accepts_auto_and_positive_ints() -> None:


### PR DESCRIPTION
Print "Exported in <duration>" after the summary, covering the whole run (load, analysis, render, metadata). Formats as seconds under a minute and minutes/seconds above; suppressed with --quiet.